### PR TITLE
Move components to `shared`

### DIFF
--- a/client/src/Bridge.re
+++ b/client/src/Bridge.re
@@ -2,3 +2,66 @@ module React = {
   include React;
   let list = el => el->Array.of_list->React.array;
 };
+
+module Dom = {
+  module Ul = {
+    [@react.component]
+    let make = (~children) => {
+      <ul> children </ul>;
+    };
+  };
+  module Form = {
+    // From tyxml:
+    // https://github.com/ocsigen/tyxml/blob/4d48e60269dc5d2f7ad62f8ef5af05b7b9e11042/lib/html_sigs.mli#L501-L502
+    // https://github.com/ocsigen/tyxml/blob/4d48e60269dc5d2f7ad62f8ef5af05b7b9e11042/lib/html_f.ml#L948-L949
+    let stringOfMethod =
+      fun
+      | `Get => "GET"
+      | `Post => "POST";
+    [@react.component]
+    let make = (~action, ~form_method, ~children) => {
+      <form action method={stringOfMethod(form_method)}> children </form>;
+    };
+  };
+  module Input = {
+    // From tyxml:
+    // https://github.com/ocsigen/tyxml/blob/4d48e60269dc5d2f7ad62f8ef5af05b7b9e11042/lib/html_sigs.mli#L526-L550
+    // https://github.com/ocsigen/tyxml/blob/4d48e60269dc5d2f7ad62f8ef5af05b7b9e11042/lib/html_f.ml#L1026
+    let stringOfInputType =
+      fun
+      | `Button => "button"
+      | `Checkbox => "checkbox"
+      | `Color => "color"
+      | `Date => "date"
+      | `Datetime => "datetime"
+      | `Datetime_local => "datetime-local"
+      | `Email => "email"
+      | `File => "file"
+      | `Hidden => "hidden"
+      | `Image => "image"
+      | `Month => "month"
+      | `Number => "number"
+      | `Password => "password"
+      | `Radio => "radio"
+      | `Range => "range"
+      | `Readonly => "readonly"
+      | `Reset => "reset"
+      | `Search => "search"
+      | `Submit => "submit"
+      | `Tel => "tel"
+      | `Text => "text"
+      | `Time => "time"
+      | `Url => "url"
+      | `Week => "week";
+    [@react.component]
+    let make = (~input_type, ~name=?, ~value=?) => {
+      <input type_={stringOfInputType(input_type)} ?name ?value />;
+    };
+  };
+  module P = {
+    [@react.component]
+    let make = (~children) => {
+      <p> children </p>;
+    };
+  };
+};

--- a/client/src/Index.re
+++ b/client/src/Index.re
@@ -1,11 +1,10 @@
 [%bs.raw {|require("./index.css")|}];
 
-
 [@bs.val] [@bs.return nullable]
 external getElementById: string => option(Dom.element) =
   "document.getElementById";
 
 switch (getElementById("root")) {
-  | Some(el) => ReactDOMRe.hydrate(<App />, el)
-  | None => ()
+| Some(el) => ReactDOMRe.hydrate(<App />, el)
+| None => ()
 };

--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@
 
   ;; Web toolkit
   (opium (>= 0.17.1))
+  (routes (>= 0.8.0))
   (reason (>= 3.6.0))
 
   ;; HTML generation

--- a/dune-project
+++ b/dune-project
@@ -33,8 +33,9 @@
   (reason (>= 3.6.0))
 
   ;; HTML generation
-  (tyxml (>= 4.4.0))
-  (tyxml-jsx (>= 4.4.0))
+  (tyxml :dev)
+  (tyxml-jsx :dev)
+  (tyxml-syntax :dev)
   
   ;; Dev dependencies
   (ocamlformat :dev)

--- a/ocaml_webapp.opam
+++ b/ocaml_webapp.opam
@@ -19,8 +19,9 @@ depends: [
   "opium" {>= "0.17.1"}
   "routes" {>= "0.8.0"}
   "reason" {>= "3.6.0"}
-  "tyxml" {>= "4.4.0"}
-  "tyxml-jsx" {>= "4.4.0"}
+  "tyxml" {dev}
+  "tyxml-jsx" {dev}
+  "tyxml-syntax" {dev}
   "ocamlformat" {dev}
 ]
 build: [
@@ -38,3 +39,8 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jchavarri/ocaml_webapp.git"
+pin-depends: [
+  [ "tyxml.dev" "git+https://github.com/jchavarri/tyxml.git#reason-react" ]
+  [ "tyxml-jsx.dev" "git+https://github.com/jchavarri/tyxml.git#reason-react" ]
+  [ "tyxml-syntax.dev" "git+https://github.com/jchavarri/tyxml.git#reason-react" ]
+]

--- a/ocaml_webapp.opam
+++ b/ocaml_webapp.opam
@@ -17,6 +17,7 @@ depends: [
   "caqti-driver-postgresql" {>= "1.2.1"}
   "ppx_rapper" {>= "0.9.2"}
   "opium" {>= "0.17.1"}
+  "routes" {>= "0.8.0"}
   "reason" {>= "3.6.0"}
   "tyxml" {>= "4.4.0"}
   "tyxml-jsx" {>= "4.4.0"}

--- a/ocaml_webapp.opam.template
+++ b/ocaml_webapp.opam.template
@@ -1,0 +1,5 @@
+pin-depends: [
+  [ "tyxml.dev" "git+https://github.com/jchavarri/tyxml.git#reason-react" ]
+  [ "tyxml-jsx.dev" "git+https://github.com/jchavarri/tyxml.git#reason-react" ]
+  [ "tyxml-syntax.dev" "git+https://github.com/jchavarri/tyxml.git#reason-react" ]
+]

--- a/server/lib/content.ml
+++ b/server/lib/content.ml
@@ -50,98 +50,20 @@ let page_with_payload payload f =
              }"))
     (f payload)
 
-(** Short hand for link formatting *)
-let hyper_link name addr = Html.(a ~a:[ a_href addr ] [ txt name ])
+let welcome_page = basic_page (Shared.PageWelcome.make ())
 
-let welcome_page =
-  basic_page
-    Html.
-      [
-        h1 [ txt "OCaml Webapp Tutorial" ];
-        h2 [ txt "Hello" ];
-        ul
-          (List.map
-             ~f:(fun x -> li [ x ])
-             [
-               hyper_link "hiya" "/hello";
-               hyper_link "中文" "/hello/中文";
-               hyper_link "Deutsch" "/hello/Deutsch";
-               hyper_link "English" "/hello/English";
-             ]);
-        h2 [ txt "Excerpts" ];
-        ul
-          (List.map
-             ~f:(fun x -> li [ x ])
-             [
-               hyper_link "Add Excerpt" "/excerpts/add";
-               hyper_link "Excerpts" "/excerpts";
-             ]);
-      ]
+let hello_page lang = basic_page (Shared.PageHello.make ~lang)
 
-let hello_page lang =
-  let greeting =
-    match lang with
-    | "中文" -> "你好，世界!"
-    | "Deutsch" -> "Hallo, Welt!"
-    | "English" -> "Hello, World!"
-    | _ ->
-      "Language not supported :(\n\
-       You can add a language via PR to \
-       https://github.com/jchavarri/ocaml_webapp"
-  in
-  basic_page Html.[ p [ txt greeting ] ]
-
-let add_excerpt_page =
-  let txt_input name =
-    Html.
-      [
-        label ~a:[ a_label_for name ] [ txt (String.capitalize name) ];
-        input ~a:[ a_input_type `Text; a_name name ] ();
-      ]
-  in
-  let excerpt_input =
-    let name = "excerpt" in
-    Html.
-      [
-        label ~a:[ a_label_for name ] [ txt (String.capitalize name) ];
-        textarea ~a:[ a_name name ] (txt "");
-      ]
-  in
-  let submit =
-    Html.[ input ~a:[ a_input_type `Submit; a_value "Submit" ] () ]
-  in
-  basic_page
-    Html.
-      [
-        form
-          ~a:[ a_method `Post; a_action "/excerpts/add" ]
-          (List.map ~f:p
-             [
-               txt_input "author";
-               excerpt_input;
-               txt_input "source";
-               txt_input "page";
-               submit;
-             ]);
-      ]
+let add_excerpt_page = basic_page (Shared.PageAddExcerpt.make ())
 
 let excerpt_added_page (e : Shared.Excerpt_t.t) =
-  basic_page
-    Html.[ p [ txt "Added the following excerpt: " ]; Shared.Excerpt.make ~e ]
+  basic_page (Shared.PageExcerptAdded.make ~excerpt:e)
 
 let excerpts_listing_page (es : Shared.Excerpt_t.t list) =
   page_with_payload es (fun es -> List.hd_exn (Shared.PageExcerpts.make ~es))
 
-let author_excerpts_link author =
-  hyper_link author (Printf.sprintf "/excerpts/author/%s" author)
-
 let author_excerpts_page authors =
-  basic_page
-    Html.
-      [
-        h1 [ txt "Authors with excerpts" ];
-        ul (List.map ~f:(fun a -> li [ author_excerpts_link a ]) authors);
-      ]
+  basic_page (Shared.PageAuthorExcerpts.make ~authors)
 
 let error_page err =
   basic_page

--- a/server/lib/content.ml
+++ b/server/lib/content.ml
@@ -87,7 +87,7 @@ let hello_page lang =
     | _ ->
       "Language not supported :(\n\
        You can add a language via PR to \
-       https://gitlab.com/shonfeder/ocaml_webapp"
+       https://github.com/jchavarri/ocaml_webapp"
   in
   basic_page Html.[ p [ txt greeting ] ]
 

--- a/server/lib/db.mli
+++ b/server/lib/db.mli
@@ -35,7 +35,10 @@ module Update : sig
 
   (** [add_excerpt excerpt req] is [Ok ()] if the new excerpt can be inserted
       into the database. *)
-  val add_excerpt : Shared.Excerpt_t.t -> Request.t -> (unit, string) Lwt_result.t
+  val add_excerpt
+    :  Shared.Excerpt_t.t ->
+    Request.t ->
+    (unit, string) Lwt_result.t
 end
 
 (** {{1} API for database migrations } *)

--- a/server/lib/dune
+++ b/server/lib/dune
@@ -1,5 +1,6 @@
 (library
  (name ocaml_webapp)
- (libraries shared core opium caqti caqti-driver-postgresql caqti-lwt tyxml lwt.unix)
+ (libraries shared core opium routes caqti caqti-driver-postgresql caqti-lwt
+   tyxml lwt.unix)
  (preprocess
   (pps ppx_rapper)))

--- a/server/lib/route.ml
+++ b/server/lib/route.ml
@@ -3,25 +3,6 @@ open Opium.Std
 (* HTML generation library *)
 open Tyxml
 
-(** The route handlers for our app *)
-
-(** Defines a handler that replies to GET requests at the root endpoint *)
-let root = get "/" (fun _req -> respond' @@ Content.welcome_page)
-
-(** Defines a handler that takes a path parameter from the route *)
-let hello =
-  get "/hello/:lang" (fun req ->
-    let lang = param req "lang" in
-    respond' @@ Content.hello_page lang)
-
-(** Fallback handler in case the endpoint is called without a language parameter *)
-let hello_fallback =
-  get "/hello" (fun _req ->
-    respond' @@ Content.basic_page Html.[ p [ txt "Hiya" ] ])
-
-let get_excerpts_add =
-  get "/excerpts/add" (fun _req -> respond' @@ Content.add_excerpt_page)
-
 let respond_or_err resp = function
   | Ok v -> respond' @@ resp v
   | Error err -> respond' @@ Content.error_page err
@@ -42,36 +23,75 @@ let excerpt_of_form_data data =
   in
   Lwt.return Shared.Excerpt_t.{ author; excerpt; source; page }
 
-let post_excerpts_add =
-  post "/excerpts/add" (fun req ->
+(** The GET route handlers for our app *)
+module Get = struct
+  (** Defines a handler that replies to requests at the root endpoint *)
+  let root _req = respond' @@ Content.welcome_page
+
+  (** Defines a handler that takes a path parameter from the route *)
+  let hello lang _req = respond' @@ Content.hello_page lang
+
+  (** Fallback handler in case the endpoint is called without a language parameter *)
+  let hello_fallback _req =
+    respond' @@ Content.basic_page Html.[ p [ txt "Hiya" ] ]
+
+  let excerpts_add _req = respond' @@ Content.add_excerpt_page
+
+  let excerpts_by_author name req =
+    let open Lwt in
+    Db.Get.excerpts_by_author name req
+    >>= respond_or_err Content.excerpts_listing_page
+
+  let excerpts req =
+    let open Lwt in
+    Db.Get.authors req >>= respond_or_err Content.author_excerpts_page
+end
+
+(** The POST route handlers for our app *)
+module Post = struct
+  let excerpts_add req =
     let open Lwt in
     (* NOTE Should handle possible error arising from invalid data *)
     App.urlencoded_pairs_of_body req >>= excerpt_of_form_data >>= fun excerpt ->
     Db.Update.add_excerpt excerpt req
-    >>= respond_or_err (fun () -> Content.excerpt_added_page excerpt))
+    >>= respond_or_err (fun () -> Content.excerpt_added_page excerpt)
+end
 
-let excerpts_by_author =
-  get "/excerpts/author/:name" (fun req ->
-    let open Lwt in
-    Db.Get.excerpts_by_author (param req "name") req
-    >>= respond_or_err Content.excerpts_listing_page)
-
-let excerpts =
-  get "/excerpts" (fun req ->
-    let open Lwt in
-    Db.Get.authors req >>= respond_or_err Content.author_excerpts_page)
-
-let routes =
+let get_routes =
+  let open Routes in
   [
-    root;
-    hello;
-    hello_fallback;
-    excerpts;
-    get_excerpts_add;
-    post_excerpts_add;
-    excerpts_by_author;
-    excerpts;
+    empty @--> Get.root;
+    (s "hello" / str /? nil) @--> Get.hello;
+    (s "hello" /? nil) @--> Get.hello_fallback;
+    (s "excerpts" / s "add" /? nil) @--> Get.excerpts_add;
+    (s "excerpts" / s "author" / str /? nil) @--> Get.excerpts_by_author;
+    (s "excerpts" /? nil) @--> Get.excerpts;
   ]
 
-let add_routes app =
-  Core.List.fold ~f:(fun app route -> route app) ~init:app routes
+let post_routes =
+  let open Routes in
+  [ (s "excerpts" / s "add" /? nil) @--> Post.excerpts_add ]
+
+let create_middleware ~get_router ~post_router =
+  let open Routes in
+  let filter handler req =
+    let target = Request.uri req |> Uri.path in
+    let meth = Request.meth req in
+    match meth with
+    | `GET ->
+      ( match match' get_router ~target with
+      | None -> handler req
+      | Some h -> h req
+      )
+    | `POST ->
+      ( match match' post_router ~target with
+      | None -> handler req
+      | Some h -> h req
+      )
+    | _ -> handler req
+  in
+  Rock.Middleware.create ~name:"Routes" ~filter
+
+let m =
+  create_middleware ~get_router:(Routes.one_of get_routes)
+    ~post_router:(Routes.one_of post_routes)

--- a/server/main.ml
+++ b/server/main.ml
@@ -9,7 +9,7 @@ let app : Opium.App.t =
   |> App.cmd_name "Ocaml Webapp Tutorial"
   |> middleware static
   |> Db.middleware
-  |> Route.add_routes
+  |> middleware Route.m
 
 let log_level = Some Logs.Debug
 

--- a/server/migrate/migrate.ml
+++ b/server/migrate/migrate.ml
@@ -1,7 +1,9 @@
 open Ocaml_webapp
 
-let create_excerpts_table = [%rapper execute
-    {sql|
+let create_excerpts_table =
+  [%rapper
+    execute
+      {sql|
     CREATE TABLE excerpts (
       excerpt_id serial PRIMARY KEY,
       author VARCHAR(100) NOT NULL,
@@ -9,14 +11,11 @@ let create_excerpts_table = [%rapper execute
       source VARCHAR(100) NOT NULL,
       page VARCHAR(20)
     )
-    |sql}
-]
+    |sql}]
 
-let migrations =
-  [ "create excerpts table", create_excerpts_table
-  ]
+let migrations = [ "create excerpts table", create_excerpts_table ]
 
 let () =
   match Lwt_main.run (Db.Migration.execute migrations) with
-  | Ok ()     -> print_endline "Migration complete"
+  | Ok () -> print_endline "Migration complete"
   | Error err -> failwith err

--- a/server/migrate/rollback.ml
+++ b/server/migrate/rollback.ml
@@ -1,16 +1,13 @@
 open Ocaml_webapp
 
-let drop_excerpts_table = [%rapper execute
-    {sql|
+let drop_excerpts_table =
+  [%rapper execute {sql|
     DROP TABLE excerpts
-    |sql}
-]
+    |sql}]
 
-let rollbacks =
-  ["drop excerpts table", drop_excerpts_table
-  ]
+let rollbacks = [ "drop excerpts table", drop_excerpts_table ]
 
 let () =
   match Lwt_main.run (Db.Migration.execute rollbacks) with
-  | Ok ()     -> print_endline "Migration complete"
+  | Ok () -> print_endline "Migration complete"
   | Error err -> failwith err

--- a/server/tyxml-reasonreact-bridge/bridge.ml
+++ b/server/tyxml-reasonreact-bridge/bridge.ml
@@ -21,3 +21,32 @@ module Js = struct
     let setTimeout : (unit -> unit) -> int -> timeoutId = fun _ _ -> ()
   end
 end
+
+module Dom = struct
+  open Tyxml.Html
+
+  module Ul = struct let createElement ~children () = ul children end
+
+  module Form = struct
+    let createElement ~action ~form_method ~children () =
+      form ~a:[ a_action action; a_method form_method ] children
+  end
+
+  module Input = struct
+    let opt_concat f el list =
+      match el with
+      | None -> list
+      | Some el -> f el :: list
+
+    let createElement ~input_type ?name ?value () =
+      input
+        ~a:
+          ([ a_input_type input_type ]
+          |> opt_concat a_name name
+          |> opt_concat a_value value
+          )
+        ()
+  end
+
+  module P = struct let createElement ~children () = p children end
+end

--- a/shared/Link.re
+++ b/shared/Link.re
@@ -1,0 +1,10 @@
+open Bridge;
+
+let createElement = (~url, ~txt, ()) => {
+  <a href=url> {React.string(txt)} </a>;
+};
+
+[@react.component]
+let make = (~url, ~txt) => {
+  createElement(~url, ~txt, ());
+};

--- a/shared/PageAddExcerpt.re
+++ b/shared/PageAddExcerpt.re
@@ -1,0 +1,39 @@
+open Bridge;
+
+[@react.component]
+let make = () => {
+  let txtInput = name =>
+    <>
+      <label for_=name>
+        {React.string(String.capitalize_ascii(name))}
+      </label>
+      <input type_=`Text name />
+    </>;
+
+  let excerptInput = {
+    let name = "excerpt";
+    <>
+      <label for_=name>
+        {React.string(String.capitalize_ascii(name))}
+      </label>
+      <textarea name> {React.string("")} </textarea>
+    </>;
+  };
+
+  let submit = <> <input type_=`Submit value="Submit" /> </>;
+
+  <>
+    {<form method=`Post action="/excerpts/add">
+       ...{List.map(
+         x => <p> ...x </p>,
+         [
+           txtInput("author"),
+           excerptInput,
+           txtInput("source"),
+           txtInput("page"),
+           submit,
+         ],
+       )}
+     </form>}
+  </>;
+};

--- a/shared/PageAddExcerpt.re
+++ b/shared/PageAddExcerpt.re
@@ -1,39 +1,41 @@
 open Bridge;
+open Dom;
 
 [@react.component]
 let make = () => {
   let txtInput = name =>
     <>
-      <label for_=name>
+      <label htmlFor=name>
         {React.string(String.capitalize_ascii(name))}
       </label>
-      <input type_=`Text name />
+      <Input input_type=`Text name />
     </>;
 
   let excerptInput = {
     let name = "excerpt";
     <>
-      <label for_=name>
+      <label htmlFor=name>
         {React.string(String.capitalize_ascii(name))}
       </label>
       <textarea name> {React.string("")} </textarea>
     </>;
   };
 
-  let submit = <> <input type_=`Submit value="Submit" /> </>;
+  let submit = <> <Input input_type=`Submit value="Submit" /> </>;
 
   <>
-    {<form method=`Post action="/excerpts/add">
-       ...{List.map(
-         x => <p> ...x </p>,
-         [
-           txtInput("author"),
-           excerptInput,
-           txtInput("source"),
-           txtInput("page"),
-           submit,
-         ],
-       )}
-     </form>}
+    {<Form form_method=`Post action="/excerpts/add">
+       {List.map(
+          x => <P> x </P>,
+          [
+            txtInput("author"),
+            excerptInput,
+            txtInput("source"),
+            txtInput("page"),
+            submit,
+          ],
+        )
+        |> React.list}
+     </Form>}
   </>;
 };

--- a/shared/PageAuthorExcerpts.re
+++ b/shared/PageAuthorExcerpts.re
@@ -14,11 +14,9 @@ module AuthorExcerptsLink = {
 let make = (~authors) => {
   <>
     <h1> {React.string("Authors with excerpts")} </h1>
-    <ul>
-      ...{List.map(
-        author => <li> <AuthorExcerptsLink author /> </li>,
-        authors,
-      )}
-    </ul>
+    <Dom.Ul>
+      {List.map(author => <li> <AuthorExcerptsLink author /> </li>, authors)
+       |> React.list}
+    </Dom.Ul>
   </>;
 };

--- a/shared/PageAuthorExcerpts.re
+++ b/shared/PageAuthorExcerpts.re
@@ -1,0 +1,24 @@
+open Bridge;
+
+module AuthorExcerptsLink = {
+  let createElement = (~author, ()) => {
+    <Link url={Printf.sprintf("/excerpts/author/%s", author)} txt=author />;
+  };
+  [@react.component]
+  let make = (~author) => {
+    createElement(~author, ());
+  };
+};
+
+[@react.component]
+let make = (~authors) => {
+  <>
+    <h1> {React.string("Authors with excerpts")} </h1>
+    <ul>
+      ...{List.map(
+        author => <li> <AuthorExcerptsLink author /> </li>,
+        authors,
+      )}
+    </ul>
+  </>;
+};

--- a/shared/PageExcerptAdded.re
+++ b/shared/PageExcerptAdded.re
@@ -1,0 +1,9 @@
+open Bridge;
+
+[@react.component]
+let make = (~excerpt as e) => {
+  <>
+    <p> {React.string("Added the following excerpt: ")} </p>
+    <Excerpt e />
+  </>;
+};

--- a/shared/PageHello.re
+++ b/shared/PageHello.re
@@ -1,0 +1,13 @@
+open Bridge;
+
+[@react.component]
+let make = (~lang) => {
+  let greeting =
+    switch (lang) {
+    | "中文" => "你好，世界!"
+    | "Deutsch" => "Hallo, Welt!"
+    | "English" => "Hello, World!"
+    | _ => "Language not supported :(\nYou can add a language via PR to https://github.com/jchavarri/ocaml_webapp"
+    };
+  <> <p> {React.string(greeting)} </p> </>;
+};

--- a/shared/PageWelcome.re
+++ b/shared/PageWelcome.re
@@ -1,0 +1,30 @@
+open Bridge;
+
+[@react.component]
+let make = () => {
+  <>
+    <h1> {React.string("OCaml Webapp Tutorial")} </h1>
+    <h2> {React.string("Hello")} </h2>
+    <ul>
+      ...{List.map(
+        x => <li> x </li>,
+        [
+          <Link url="/hello" txt="hiya" />,
+          <Link url="/hello/中文" txt="中文" />,
+          <Link url="/hello/Deutsch" txt="Deutsch" />,
+          <Link url="/hello/English" txt="English" />,
+        ],
+      )}
+    </ul>
+    <h2> {React.string("Excerpts")} </h2>
+    <ul>
+      ...{List.map(
+        x => <li> x </li>,
+        [
+          <Link url="/excerpts/add" txt="Add Excerpt" />,
+          <Link url="/excerpts" txt="Excerpts" />,
+        ],
+      )}
+    </ul>
+  </>;
+};

--- a/shared/PageWelcome.re
+++ b/shared/PageWelcome.re
@@ -5,26 +5,28 @@ let make = () => {
   <>
     <h1> {React.string("OCaml Webapp Tutorial")} </h1>
     <h2> {React.string("Hello")} </h2>
-    <ul>
-      ...{List.map(
-        x => <li> x </li>,
-        [
-          <Link url="/hello" txt="hiya" />,
-          <Link url="/hello/中文" txt="中文" />,
-          <Link url="/hello/Deutsch" txt="Deutsch" />,
-          <Link url="/hello/English" txt="English" />,
-        ],
-      )}
-    </ul>
+    <Dom.Ul>
+      {List.map(
+         x => <li> x </li>,
+         [
+           <Link url="/hello" txt="hiya" />,
+           <Link url="/hello/中文" txt="中文" />,
+           <Link url="/hello/Deutsch" txt="Deutsch" />,
+           <Link url="/hello/English" txt="English" />,
+         ],
+       )
+       |> React.list}
+    </Dom.Ul>
     <h2> {React.string("Excerpts")} </h2>
-    <ul>
-      ...{List.map(
-        x => <li> x </li>,
-        [
-          <Link url="/excerpts/add" txt="Add Excerpt" />,
-          <Link url="/excerpts" txt="Excerpts" />,
-        ],
-      )}
-    </ul>
+    <Dom.Ul>
+      {List.map(
+         x => <li> x </li>,
+         [
+           <Link url="/excerpts/add" txt="Add Excerpt" />,
+           <Link url="/excerpts" txt="Excerpts" />,
+         ],
+       )
+       |> React.list}
+    </Dom.Ul>
   </>;
 };

--- a/shared/dune
+++ b/shared/dune
@@ -1,6 +1,7 @@
 (library
  (name shared)
  (libraries bridge tyxml)
- (preprocess (pps tyxml-jsx))
+ (preprocess
+  (pps tyxml-jsx))
  (flags
   (:standard -open Tyxml)))


### PR DESCRIPTION
- move all components to `shared`
- make sure they all compile in both server and client

For this, it was required to [patch `tyxml-jsx`](https://github.com/jchavarri/tyxml/tree/reason-react) so that elements created from uppercase components that only have one child don't wrap it in a list, to behave the same than reason-react: https://github.com/rescript-lang/rescript-compiler/blob/8e9f537ec5020534f6405d707c1803a2b96a6d0e/jscomp/syntax/reactjs_jsx_ppx.cppo.ml#L89.

This leaves the same issue for lower case components (e.g. `<div> List.map(...) </div>`), but this was solved for now by wrapping them separately on the `bridge` implementation.